### PR TITLE
Bump openjdk from 14-jdk-alpine to 16-jdk-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-jdk-alpine
+FROM openjdk:16-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG JAR_FILE=build/libs/*.jar


### PR DESCRIPTION
Bumps openjdk from 14-jdk-alpine to 16-jdk-alpine.

Signed-off-by: dependabot[bot] <support@github.com>